### PR TITLE
Fix console users list for multiple logins. Refactoring.

### DIFF
--- a/networkhomedirmountwatch.py
+++ b/networkhomedirmountwatch.py
@@ -5,22 +5,32 @@ import sys
 import os
 import syslog
 
+
+def check_call_with_errhandler(cmd):
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as err:
+        syslog.syslog(syslog.LOG_ALERT, '%s: %s' % (err, err.message))
+
+
+def log(msg):
+    syslog.syslog(syslog.LOG_ALERT, msg)
+
+
 syslog.openlog('NetworkHomeDirMountWatch')
 
+# Is there a .localized folder hidden here?
 mountedHomes = os.listdir('/home')
-consoleUsers = subprocess.check_output(['/usr/bin/users'])
+consoleUsers = subprocess.check_output(['/usr/bin/users']).split()
+networkConsoleUsers = [user for user in consoleUsers if user in mountedHomes]
 
 for home in mountedHomes:
-	try:
-		if home in consoleUsers:
-			syslog.syslog(syslog.LOG_ALERT, 'User ' + home + ' still logged in.')
-		else:
-			syslog.syslog(syslog.LOG_ALERT, 'Killing processes for ' + home + '.')
-			homeDir = '/home/' + home
-			subprocess.call(['/usr/bin/killall' ,'-9', '-u', home])
-			syslog.syslog(syslog.LOG_ALERT, 'Forcing unmount of network home for ' + home + '.')
-			subprocess.call(['/sbin/umount', '-f', homeDir]) 
-	except:
-		print error
+    if home in networkConsoleUsers:
+        log('User %s still logged in.' % home)
+    else:
+        log('Killing processes for %s.' % home)
+        check_call_with_errhandler(['/usr/bin/killall' ,'-9', '-u', home])
 
-
+        log('Forcing unmount of network home ' 'for %s.' % home)
+        homeDir = os.path.join('/home', home)
+        check_call_with_errhandler(['/sbin/umount', '-f', homeDir])


### PR DESCRIPTION
- Refactor subprocess.check_call into a function.
- Wrap points of probably exceptions more closely (check_call's)
- Refactor logging into simple function.
- Add .split() to `users` call to properly parse a returned list and
  remove newlines.
- Determine which users are network home users and which are local and
  only loop over the networked ones.
- Use os.path.join() for constructing paths to be safe.
- Main try/except had undefined `error` variable. Restated in
  refactoring above passes error and error.message to syslogging
  facility.
